### PR TITLE
Simplify transformer

### DIFF
--- a/transformer.ts
+++ b/transformer.ts
@@ -40,9 +40,9 @@ function isEnumerateCallExpression(node: ts.Node, typeChecker: ts.TypeChecker): 
 
   return !!declaration
     && !ts.isJSDocSignature(declaration)
-    && (path.join(declaration.getSourceFile().fileName) === indexTs)
-    && !!(declaration.name)
-    && ((declaration.name).getText() === 'enumerate');
+    && path.join(declaration.getSourceFile().fileName) === indexTs
+    && !!declaration.name
+    && declaration.name.getText() === 'enumerate';
 }
 
 function resolveStringLiteralTypes(node: ts.Node, typeChecker: ts.TypeChecker, literals: ts.LiteralTypeNode['literal'][]): void {

--- a/transformer.ts
+++ b/transformer.ts
@@ -26,10 +26,10 @@ function visitNode(node: ts.Node, program: ts.Program): ts.Node {
 
 const indexTs = path.join(__dirname, 'index.ts');
 function isEnumerateCallExpression(node: ts.Node, typeChecker: ts.TypeChecker): node is ts.CallExpression {
-  if (node.kind !== ts.SyntaxKind.CallExpression) {
+  if (!ts.isCallExpression(node)) {
     return false;
   }
-  const signature = typeChecker.getResolvedSignature(node as ts.CallExpression);
+  const signature = typeChecker.getResolvedSignature(node);
   if (typeof signature === 'undefined') {
     return false;
   }

--- a/transformer.ts
+++ b/transformer.ts
@@ -25,15 +25,19 @@ function visitNode(node: ts.Node, program: ts.Program): ts.Node {
 }
 
 const indexTs = path.join(__dirname, 'index.ts');
+
 function isEnumerateCallExpression(node: ts.Node, typeChecker: ts.TypeChecker): node is ts.CallExpression {
   if (!ts.isCallExpression(node)) {
     return false;
   }
   const signature = typeChecker.getResolvedSignature(node);
+
   if (typeof signature === 'undefined') {
     return false;
   }
+
   const { declaration } = signature;
+
   return !!declaration
     && !ts.isJSDocSignature(declaration)
     && (path.join(declaration.getSourceFile().fileName) === indexTs)

--- a/transformer.ts
+++ b/transformer.ts
@@ -35,9 +35,10 @@ function isEnumerateCallExpression(node: ts.Node, typeChecker: ts.TypeChecker): 
   }
   const { declaration } = signature;
   return !!declaration
+    && !ts.isJSDocSignature(declaration)
     && (path.join(declaration.getSourceFile().fileName) === indexTs)
-    && !!(declaration as any)['name']
-    && ((declaration as any)['name'].getText() === 'enumerate');
+    && !!(declaration.name)
+    && ((declaration.name).getText() === 'enumerate');
 }
 
 function resolveStringLiteralTypes(node: ts.Node, typeChecker: ts.TypeChecker, literals: ts.LiteralTypeNode['literal'][]): void {


### PR DESCRIPTION
In particular, removes the need for the `as x` casts.